### PR TITLE
chore: promote release → master (branch standardization)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
     json5 "^2.1.2"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -54,7 +54,7 @@
   dependencies:
     "@babel/types" "^7.10.2"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     source-map "^0.5.0"
 
 "@babel/generator@^7.4.0", "@babel/generator@^7.9.0":
@@ -64,7 +64,7 @@
   dependencies:
     "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.8.3":
@@ -159,7 +159,7 @@
   dependencies:
     "@babel/helper-function-name" "^7.8.3"
     "@babel/types" "^7.8.3"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-explode-assignable-expression@^7.8.3":
   version "7.8.3"
@@ -240,7 +240,7 @@
     "@babel/helper-split-export-declaration" "^7.8.3"
     "@babel/template" "^7.8.6"
     "@babel/types" "^7.9.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.1":
   version "7.10.1"
@@ -271,7 +271,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
   integrity sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==
   dependencies:
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-remap-async-to-generator@^7.8.3":
   version "7.8.3"
@@ -593,7 +593,7 @@
   integrity sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/plugin-transform-classes@^7.9.0":
   version "7.9.0"
@@ -1043,7 +1043,7 @@
     "@babel/types" "^7.9.0"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/traverse@^7.10.1":
   version "7.10.1"
@@ -1058,7 +1058,7 @@
     "@babel/types" "^7.10.1"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7", "@babel/types@^7.9.0":
   version "7.9.0"
@@ -1066,7 +1066,7 @@
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.10.1", "@babel/types@^7.10.2":
@@ -1075,7 +1075,7 @@
   integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":


### PR DESCRIPTION
## Summary
- Promote release into master lane (branch standardization)
- Completing the `develop → release → master` flow for legacy repos

## Triad Verdict
Triad executada — Verdict: PASS (legacy code, no new features, standardization only)

## Risks
- Legacy dependencies with known vulnerabilities (dependabot alerts pending batch merge)
- No CI/CD configured — no automated validation before merge

## Rollback
- Revert the merge commit on master branch
- No production deployment impact (legacy/archive repos)